### PR TITLE
Use Miniconda3 version 4.3.21 rather than latest

### DIFF
--- a/build_scripts/build_python.sh
+++ b/build_scripts/build_python.sh
@@ -3,9 +3,9 @@
 export LANG="C.UTF-8"
 export LC_ALL="C.UTF-8"
 
-wget --quiet https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.3.21-Linux-x86_64.sh
 
-bash Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda
+bash Miniconda3-4.3.21-Linux-x86_64.sh -b -p /miniconda
 
 pip install \
     boto3==1.7.66 \


### PR DESCRIPTION
#### The problem

The "latest" version of `Miniconda3` is based on `Python 3.7`, which is incompatible with `Djano 1.11.3`.
When this version of `Miniconda3` is used, the Docker images cannot be started because an exception like the following is thrown: 
```
web_1     | SyntaxError: Generator expression must be parenthesized
web_1     | Traceback (most recent call last):
web_1     |   File "manage.py", line 22, in <module>
web_1     |     execute_from_command_line(sys.argv)
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/core/management/__init__.py", line 363, in execute_from_command_line
web_1     |     utility.execute()
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/core/management/__init__.py", line 337, in execute
web_1     |     django.setup()
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/__init__.py", line 27, in setup
web_1     |     apps.populate(settings.INSTALLED_APPS)
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/apps/registry.py", line 85, in populate
web_1     |     app_config = AppConfig.create(entry)
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/apps/config.py", line 94, in create
web_1     |     module = import_module(entry)
web_1     |   File "/miniconda/lib/python3.7/importlib/__init__.py", line 127, in import_module
web_1     |     return _bootstrap._gcd_import(name[level:], package, level)
web_1     |   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
web_1     |   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
web_1     |   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
web_1     |   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
web_1     |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
web_1     |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/contrib/admin/__init__.py", line 4, in <module>
web_1     |     from django.contrib.admin.filters import (
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/contrib/admin/filters.py", line 10, in <module>
web_1     |     from django.contrib.admin.options import IncorrectLookupParameters
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/contrib/admin/options.py", line 12, in <module>
web_1     |     from django.contrib.admin import helpers, widgets
web_1     |   File "/miniconda/lib/python3.7/site-packages/django/contrib/admin/widgets.py", line 151
web_1     |     '%s=%s' % (k, v) for k, v in params.items(),
```

#### Proposed fix 
By changing to `Miniconda3 latest` to `Miniconda3 4.3.21` (which I assume was `"latest"` at project inception based on the Django version), `Python 3.6` is enforced and the Docker image can actually be built and started.